### PR TITLE
Support multiple items per check

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,30 +76,40 @@ check against multiple targets.
 For example, to check multiple executable installations:
 
 ```yaml
-- name: Check binary installations
+- name: "Check binary installations"
   type: os.executable_exists
   items:
     - name: git
+      path: /usr/local/bin
     - name: docker
-    - name: my-tool
-    - name: checkers
 ```
 
 This will be expanded into multiple checks, each checking a different
-executable. The check names will be automatically generated as `{check-name}:
-{index}`.
+executable. By default, check names will be automatically generated as `{check-name}: {index}`.
 
-Similarly, you can check multiple S3 buckets:
+You can customize the check names using Go template syntax to reference any parameter from your items.
+The template has access to all parameters defined in each item. For example:
 
 ```yaml
-- name: Check S3 access
-  type: cloud.aws_s3_access
+- name: "Check binary: {{ .name }}"
+  type: os.executable_exists
   items:
-    - bucket: "data-bucket"
-    - bucket: "backup-bucket"
+    - name: git
+      path: /usr/local/bin
+    - name: docker
 ```
 
-Each item in the list should contain all the parameters required by the check type.
+This will create two checks:
+1. `Check binary: git` (with parameters `name: git` and `path: /usr/local/bin`)
+2. `Check binary: docker` (with parameters `name: docker`)
+
+The template syntax follows Go's [text/template](https://pkg.go.dev/text/template) package rules:
+- Use `{{ .key }}` to reference a parameter value, where `key` is the parameter name
+- Parameter names are case-sensitive
+- If a referenced parameter is missing, the check will fail validation
+
+Each item in the list must contain all the parameters required by the check
+type. The validation will fail if any required parameters are missing.
 
 ## Command Line Options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,12 +56,50 @@ shown.
 
 Each check in the `checks` list requires the following fields:
 
-| Field      | Type   | Required         | Description                                              |
-| ---------- | ------ | ---------------- | -------------------------------------------------------- |
-| name       | string | Yes              | Unique identifier for the check                          |
-| type       | string | Yes              | Type of check to perform (e.g., command, os.file_exists) |
-| command    | string | For command type | Shell command to execute                                 |
-| parameters | map    | No               | Additional parameters specific to check type             |
+| Field      | Type   | Required         | Description                                                              |
+| ---------- | ------ | ---------------- | ------------------------------------------------------------------------ |
+| name       | string | Yes              | Unique identifier for the check                                          |
+| type       | string | Yes              | Type of check to perform (e.g., command, os.file_exists)                 |
+| command    | string | No\*             | Shell command to execute                                                 |
+| parameters | map    | No\*             | Additional parameters specific to check type                             |
+| items      | list   | No\*             | List of parameter sets for running multiple variations of the same check |
+
+\* Note: `command`, `parameters`, and `items` are mutually exclusive. A check must have exactly one of these fields.
+
+### Multiple Items Configuration
+
+The `items` field allows you to run the same check with different parameters.
+Each item in the list represents a set of parameters for a separate instance of
+the check. This is particularly useful when you want to run the same type of
+check against multiple targets.
+
+For example, to check multiple executable installations:
+
+```yaml
+- name: Check binary installations
+  type: os.executable_exists
+  items:
+    - name: git
+    - name: docker
+    - name: my-tool
+    - name: checkers
+```
+
+This will be expanded into multiple checks, each checking a different
+executable. The check names will be automatically generated as `{check-name}:
+{index}`.
+
+Similarly, you can check multiple S3 buckets:
+
+```yaml
+- name: Check S3 access
+  type: cloud.aws_s3_access
+  items:
+    - bucket: "data-bucket"
+    - bucket: "backup-bucket"
+```
+
+Each item in the list should contain all the parameters required by the check type.
 
 ## Command Line Options
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/seastar-consulting/checkers/types"
 	"os"
+
+	"github.com/seastar-consulting/checkers/types"
 
 	"github.com/seastar-consulting/checkers/internal/errors"
 	"gopkg.in/yaml.v3"
@@ -37,6 +38,27 @@ func (m *Manager) Load() (*types.Config, error) {
 		return nil, err
 	}
 
+	// Expand checks with multiple items
+	var expandedChecks []types.CheckItem
+	for _, check := range config.Checks {
+		if len(check.Items) > 0 {
+			// For each item in the list, create a new check
+			for i, item := range check.Items {
+				newCheck := types.CheckItem{
+					Name:        fmt.Sprintf("%s: %d", check.Name, i+1),
+					Type:        check.Type,
+					Description: check.Description,
+					Command:     check.Command,
+					Parameters:  item,
+				}
+				expandedChecks = append(expandedChecks, newCheck)
+			}
+		} else {
+			expandedChecks = append(expandedChecks, check)
+		}
+	}
+
+	config.Checks = expandedChecks
 	return &config, nil
 }
 
@@ -47,11 +69,44 @@ func (m *Manager) validate(config *types.Config) error {
 	}
 
 	for _, check := range config.Checks {
+		// Validate required fields
 		if check.Name == "" {
 			return errors.NewConfigError("check.name", fmt.Errorf("check name is required"))
 		}
 		if check.Type == "" {
 			return errors.NewConfigError("check.type", fmt.Errorf("check type is required for check %q", check.Name))
+		}
+
+		// Count how many of the mutually exclusive fields are set
+		fieldsSet := 0
+		if check.Command != "" {
+			fieldsSet++
+		}
+		if len(check.Parameters) > 0 {
+			fieldsSet++
+		}
+		if len(check.Items) > 0 {
+			fieldsSet++
+		}
+
+		// Enforce exactly one field must be set
+		if fieldsSet == 0 {
+			return errors.NewConfigError("check.fields",
+				fmt.Errorf("check %q must have exactly one of 'command', 'parameters', or 'items' fields", check.Name))
+		}
+		if fieldsSet > 1 {
+			return errors.NewConfigError("check.fields",
+				fmt.Errorf("check %q cannot have multiple of 'command', 'parameters', and 'items' fields", check.Name))
+		}
+
+		// If Items is used, ensure each item has parameters
+		if len(check.Items) > 0 {
+			for i, item := range check.Items {
+				if len(item) == 0 {
+					return errors.NewConfigError("check.items",
+						fmt.Errorf("item %d in check %q must have parameters", i, check.Name))
+				}
+			}
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,6 +163,45 @@ checks:
 			wantErr:     true,
 			errContains: "must have parameters",
 		},
+		{
+			name: "valid config with items and name template",
+			configYAML: `
+checks:
+  - name: "Check binary: {{ .name }}"
+    type: test
+    items:
+      - path: else
+        name: git
+      - name: docker
+`,
+			wantErr:    false,
+			wantChecks: 2,
+			checkNames: []string{"Check binary: git", "Check binary: docker"},
+		},
+		{
+			name: "invalid template syntax",
+			configYAML: `
+checks:
+  - name: "Check binary: {{ .name"
+    type: test
+    items:
+      - name: git
+`,
+			wantErr:     true,
+			errContains: "invalid template in check name",
+		},
+		{
+			name: "missing template field",
+			configYAML: `
+checks:
+  - name: "Check binary: {{ .missing }}"
+    type: test
+    items:
+      - name: git
+`,
+			wantErr:     true,
+			errContains: "failed to render check name template",
+		},
 	}
 
 	for _, tt := range tests {

--- a/types/config.go
+++ b/types/config.go
@@ -2,13 +2,14 @@ package types
 
 import "time"
 
-// CheckItem represents individual check configurations
+// CheckItem represents a single check to be executed
 type CheckItem struct {
-	Name        string            `yaml:"name"`
-	Description string            `yaml:"description,omitempty"`
-	Type        string            `yaml:"type"`
-	Command     string            `yaml:"command,omitempty"`
-	Parameters  map[string]string `yaml:"parameters,omitempty"`
+	Name        string              `yaml:"name"`
+	Description string              `yaml:"description,omitempty"`
+	Type        string              `yaml:"type"`
+	Command     string              `yaml:"command,omitempty"`
+	Parameters  map[string]string   `yaml:"parameters,omitempty"`
+	Items       []map[string]string `yaml:"items,omitempty"`
 }
 
 // Config represents the structure of the checks.yaml file


### PR DESCRIPTION
For example one can check many binaries in one check definition.
Internally the unmarshalling of the configuration yields a new check of
the same type per item defined. For example:

```yaml
checks:
  - name: test-check
    type: test
    items:
      - name: item1
        path: /path1
      - name: item2
        path: /path2
```